### PR TITLE
chore: simplify version retrieval in prebuild script

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  issues: write
 jobs:
   release:
     name: Release
@@ -37,13 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: production
         run: npx semantic-release
-
-      - name: Prebuild version with semantic version
-        run: |
-          # Get the latest version from git tags (set by semantic-release)
-          VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
-          echo "Using semantic version: $VERSION"
-          SEMANTIC_RELEASE_VERSION=$VERSION npm run prebuild-version
 
       - name: Build project
         run: npm run build:prod

--- a/scripts/prebuild-version.js
+++ b/scripts/prebuild-version.js
@@ -2,33 +2,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 // Read package.json
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-// Try to get version from semantic-release environment variables first (CI/CD)
-let version = packageJson.version;
-if (process.env.SEMANTIC_RELEASE_VERSION) {
-    version = process.env.SEMANTIC_RELEASE_VERSION;
-    console.log('Using version from semantic-release:', version);
-} else {
-    // Try to get version from git tags (semantic versioning)
-    try {
-        // Get the latest git tag
-        const latestTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
-        if (latestTag) {
-            // Remove 'v' prefix if present
-            version = latestTag.replace(/^v/, '');
-            console.log('Using version from git tag:', version);
-        }
-    } catch (error) {
-        console.log('No git tags found, using package.json version:', version);
-    }
-}
-
 // Get git information
+const { execSync } = require('child_process');
 let commitHash = 'unknown';
 let buildDate = new Date().toISOString().split('T')[0];
 
@@ -40,7 +20,7 @@ try {
 
 // Generate version info
 const versionInfo = {
-    version: version,
+    version: packageJson.version,
     buildDate: buildDate,
     commitHash: commitHash
 };


### PR DESCRIPTION
- Remove the logic for fetching version from semantic-release environment variables and git tags.
- Directly use the version from package.json for consistency in versioning information.